### PR TITLE
Fix potential NPEs in AI repository

### DIFF
--- a/ml/src/main/java/com/uoa/ml/data/repository/AIModelInputRepositoryImpl.kt
+++ b/ml/src/main/java/com/uoa/ml/data/repository/AIModelInputRepositoryImpl.kt
@@ -88,7 +88,9 @@ class AIModelInputRepositoryImpl @Inject constructor(
             // Update incremental calculators
             incrementalHourOfDayMeanProvider.addTimestamp(sensorData.timestamp)
             incrementalDayOfWeekMeanProvider.addTimestamp(sensorData.timestamp)
-            incrementalSpeedStdProvider.addSpeed(location.speed!!.toFloat())
+            location.speed?.toFloat()?.let { speed ->
+                incrementalSpeedStdProvider.addSpeed(speed)
+            }
 
             if (sensorData.sensorType == Sensor.TYPE_ACCELEROMETER) {
                 val accelerationY = sensorData.values.getOrNull(1) ?: return
@@ -112,10 +114,11 @@ class AIModelInputRepositoryImpl @Inject constructor(
 
                 // Store trip features in the database
                 val timestamp = Instant.now().toEpochMilli()
+                val driverId = PreferenceUtils.getDriverProfileId(context) ?: return
                 val aiModelInputs= AIModelInputsEntity(
                     id= UUID.randomUUID(),
                     tripId= tripId,
-                    driverProfileId =PreferenceUtils.getDriverProfileId(context)!!,
+                    driverProfileId = driverId,
                     timestamp=System.currentTimeMillis().toLong(),
                     startTimestamp=System.currentTimeMillis().toLong(),
                     endTimestamp=System.currentTimeMillis().toLong(),

--- a/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/ReportScreen.kt
+++ b/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/ReportScreen.kt
@@ -283,7 +283,9 @@ fun ReportScreenRoute(
     LaunchedEffect(generatedPrompt) {
         if (generatedPrompt.isNotEmpty()) {
 //            Log.d("ReportScreen", "Generated Prompt: $generatedPrompt")
-            chatGPTViewModel.promptChatGPTForResponse(generatedPrompt, periodType, PreferenceUtils.getDriverProfileId(appContext)!!)
+            PreferenceUtils.getDriverProfileId(appContext)?.let { profileId ->
+                chatGPTViewModel.promptChatGPTForResponse(generatedPrompt, periodType, profileId)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid `!!` that could crash when driver profile ID is missing
- guard against null speed in AI input processing
- check profile ID before querying chat GPT

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685166fff4c48332a8c650b21fd89d64