### PR TITLE
Fix crashes from invalid preferences

### DIFF
--- a/app/src/androidTest/java/com/uoa/driveafrica/ui/splashscreens/EntryFlowTest.kt
+++ b/app/src/androidTest/java/com/uoa/driveafrica/ui/splashscreens/EntryFlowTest.kt
@@ -1,0 +1,39 @@
+package com.uoa.driveafrica.ui.splashscreens
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.uoa.driveafrica.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Basic UI flow tests covering the splash screens.
+ */
+@RunWith(AndroidJUnit4::class)
+class EntryFlowTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun appLaunchShowsWelcomeScreen() {
+        composeTestRule.onNodeWithText("Welcome to the Safe Drive Africa APP").assertExists()
+    }
+
+    @Test
+    fun continueFromWelcomeNavigatesToDisclaimer() {
+        composeTestRule.onNodeWithText("Continue").performClick()
+        composeTestRule.onNodeWithText("Disclaimer").assertExists()
+    }
+
+    @Test
+    fun continueFromDisclaimerNavigatesToEntryPoint() {
+        composeTestRule.onNodeWithText("Continue").performClick()
+        composeTestRule.onNodeWithText("Disclaimer").assertExists()
+        composeTestRule.onNodeWithText("Continue").performClick()
+        composeTestRule.onNodeWithTag("entryPointProgress").assertExists()
+    }
+}

--- a/app/src/main/java/com/uoa/driveafrica/ui/appentrypoint/EntryPointScreen.kt
+++ b/app/src/main/java/com/uoa/driveafrica/ui/appentrypoint/EntryPointScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 
 @Composable
 fun EntryPointScreen() {
@@ -13,6 +14,6 @@ fun EntryPointScreen() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        CircularProgressIndicator()
+        CircularProgressIndicator(modifier = Modifier.testTag("entryPointProgress"))
     }
 }

--- a/core/src/main/java/com/uoa/core/utils/PreferenceUtils.kt
+++ b/core/src/main/java/com/uoa/core/utils/PreferenceUtils.kt
@@ -11,13 +11,21 @@ object PreferenceUtils {
 
     fun getDriverProfileId(context: Context): UUID? {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val profileIdString = prefs.getString(DRIVER_PROFILE_ID, null)
-        return profileIdString?.let { UUID.fromString(it) }
+        val profileIdString = prefs.getString(DRIVER_PROFILE_ID, null) ?: return null
+        return try {
+            UUID.fromString(profileIdString)
+        } catch (e: IllegalArgumentException) {
+            null
+        }
     }
 
     fun getTripId(context:Context): UUID?{
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val tripString = prefs.getString(TRIP_ID, null)
-        return tripString?.let { UUID.fromString(it) }
+        val tripString = prefs.getString(TRIP_ID, null) ?: return null
+        return try {
+            UUID.fromString(tripString)
+        } catch (e: IllegalArgumentException) {
+            null
+        }
     }
 }

--- a/driverprofile/src/main/java/com/uoa/driverprofile/presentation/viewmodel/DrivingTipsViewModel.kt
+++ b/driverprofile/src/main/java/com/uoa/driverprofile/presentation/viewmodel/DrivingTipsViewModel.kt
@@ -184,8 +184,9 @@ class DrivingTipsViewModel @Inject constructor(
                 val contextText = compressAndEncodeJson(context)
                 val prompt = createAIPromptFromChunks(unsafeBehavior, contextText, context)
                 Log.d("DrivingTipsViewModel", "Generated prompt for AI models")
-                val geminiResponse = geminiCaller.generateContent(prompt)
-                val geminiTipContent = geminiResponse.text?.let { parseTipContent(it, "gemini", profileId) }
+                val geminiTipContent = runCatching {
+                    geminiCaller.generateContent(prompt)
+                }.getOrNull()?.text?.let { parseTipContent(it, "gemini", profileId) }
                 val requestBody = RequestBody(
                     model = "gpt-3.5-turbo",
                     messages = listOf(Message(role = "user", content = prompt)),

--- a/ml/src/main/java/com/uoa/ml/data/repository/AIModelInputRepositoryImpl.kt
+++ b/ml/src/main/java/com/uoa/ml/data/repository/AIModelInputRepositoryImpl.kt
@@ -88,7 +88,9 @@ class AIModelInputRepositoryImpl @Inject constructor(
             // Update incremental calculators
             incrementalHourOfDayMeanProvider.addTimestamp(sensorData.timestamp)
             incrementalDayOfWeekMeanProvider.addTimestamp(sensorData.timestamp)
-            incrementalSpeedStdProvider.addSpeed(location.speed!!.toFloat())
+            location.speed?.toFloat()?.let { speed ->
+                incrementalSpeedStdProvider.addSpeed(speed)
+            }
 
             if (sensorData.sensorType == Sensor.TYPE_ACCELEROMETER) {
                 val accelerationY = sensorData.values.getOrNull(1) ?: return
@@ -112,10 +114,11 @@ class AIModelInputRepositoryImpl @Inject constructor(
 
                 // Store trip features in the database
                 val timestamp = Instant.now().toEpochMilli()
+                val driverId = PreferenceUtils.getDriverProfileId(context) ?: return
                 val aiModelInputs= AIModelInputsEntity(
                     id= UUID.randomUUID(),
                     tripId= tripId,
-                    driverProfileId =PreferenceUtils.getDriverProfileId(context)!!,
+                    driverProfileId = driverId,
                     timestamp=System.currentTimeMillis().toLong(),
                     startTimestamp=System.currentTimeMillis().toLong(),
                     endTimestamp=System.currentTimeMillis().toLong(),

--- a/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/ReportScreen.kt
+++ b/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/ReportScreen.kt
@@ -283,7 +283,9 @@ fun ReportScreenRoute(
     LaunchedEffect(generatedPrompt) {
         if (generatedPrompt.isNotEmpty()) {
 //            Log.d("ReportScreen", "Generated Prompt: $generatedPrompt")
-            chatGPTViewModel.promptChatGPTForResponse(generatedPrompt, periodType, PreferenceUtils.getDriverProfileId(appContext)!!)
+            PreferenceUtils.getDriverProfileId(appContext)?.let { profileId ->
+                chatGPTViewModel.promptChatGPTForResponse(generatedPrompt, periodType, profileId)
+            }
         }
     }
 

--- a/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreen.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreen.kt
@@ -308,8 +308,10 @@ import com.uoa.core.apiServices.workManager.UploadAllDataWorker
                                     if (isVehicleMoving) {
                                         tripID = UUID.randomUUID()
                                         prefs.edit().putString(TRIP_ID, tripID.toString()).apply()
-                                        tripViewModel.updateTripId(tripID!!)
-                                        tripViewModel.startTrip(driverProfileId, tripID!!)
+                                        tripID?.let { id ->
+                                            tripViewModel.updateTripId(id)
+                                            tripViewModel.startTrip(driverProfileId, id)
+                                        }
 
                                         // Start DataCollectionService
                                         val sensorIntent = Intent(context, DataCollectionService::class.java).apply {
@@ -330,8 +332,8 @@ import com.uoa.core.apiServices.workManager.UploadAllDataWorker
                                     // End trip and data collection
                                     val tripIdString = prefs.getString(TRIP_ID, null)
                                     tripID = tripIdString?.let { UUID.fromString(it) }
-                                    if (tripID != null) {
-                                        tripViewModel.endTrip(tripID!!)
+                                    tripID?.let { id ->
+                                        tripViewModel.endTrip(id)
                                         prefs.edit().remove("TRIP_ID").apply()
                                         tripViewModel.clearTripID()
 
@@ -339,9 +341,8 @@ import com.uoa.core.apiServices.workManager.UploadAllDataWorker
                                         val sensorDataCollectionIntent = Intent(context, DataCollectionService::class.java)
                                         context.stopService(sensorDataCollectionIntent)
                                         Toast.makeText(context, "Trip Ended Successfully.", Toast.LENGTH_LONG).show()
-
                                         tripID = null
-                                    } else {
+                                    } ?: run {
                                         Toast.makeText(context, "Trip Ended Successfully.", Toast.LENGTH_LONG).show()
                                     }
                                 }


### PR DESCRIPTION
## Summary
- handle invalid UUID strings in `PreferenceUtils`
- avoid using null `tripID` when starting or ending trips
- catch Gemini API errors in `DrivingTipsViewModel`

## Testing
- `./gradlew test` *(fails: the file '/workspace/driveafrica/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_685166fff4c48332a8c650b21fd89d64