### PR TITLE
Limit questionnaire to once per day

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Alternatively, you can export the environment variables `GEMINI_API_KEY` and `CH
 - Periodically uploads sensor and location data to the Safe Drive Africa backend via `UploadAllDataWorker`.
 - Uses a generative model (ChatGPT or Gemini) to craft custom feedback reports.
 - Includes an alcohol questionnaire and driver profiling to enrich the data set.
+- The alcohol questionnaire appears at most once per day when you open the app.
 - Part of a PhD project at the University of Aberdeen, Scotland, as introduced on the welcome screen.
 
 ## Privacy and data usage

--- a/app/src/main/java/com/uoa/driveafrica/presentation/daappnavigation/EntryPointNavigation.kt
+++ b/app/src/main/java/com/uoa/driveafrica/presentation/daappnavigation/EntryPointNavigation.kt
@@ -13,9 +13,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.uoa.alcoholquestionnaire.presentation.ui.questionnairenavigation.navigateToQuestionnaire
 import com.uoa.core.utils.Constants.Companion.DRIVER_PROFILE_ID
+import com.uoa.core.utils.Constants.Companion.LAST_QUESTIONNAIRE_DAY
 import com.uoa.core.utils.Constants.Companion.PREFS_NAME
 import com.uoa.core.utils.ENTRYPOINT_ROUTE
 import com.uoa.driverprofile.presentation.ui.navigation.navigateToOnboardingScreen
+import com.uoa.driverprofile.presentation.ui.navigation.navigateToHomeScreen
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 fun NavGraphBuilder.entryPointScreen(
     navController: NavController
@@ -24,6 +28,8 @@ fun NavGraphBuilder.entryPointScreen(
         val context = LocalContext.current
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val savedProfileId = prefs.getString(DRIVER_PROFILE_ID, null)
+        val lastDay = prefs.getString(LAST_QUESTIONNAIRE_DAY, null)
+        val today = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
 
         // We only run this logic once
         LaunchedEffect(Unit) {
@@ -33,9 +39,27 @@ fun NavGraphBuilder.entryPointScreen(
                     popUpTo(ENTRYPOINT_ROUTE) { inclusive = true }
                 }
             } else {
-                // Profile exists => go to questionnaire every time
-                navController.navigateToQuestionnaire {
-                    popUpTo(ENTRYPOINT_ROUTE) { inclusive = true }
+                val shouldShowQuestionnaire = lastDay != today
+                if (shouldShowQuestionnaire) {
+                    prefs.edit().putString(LAST_QUESTIONNAIRE_DAY, today).apply()
+                    navController.navigateToQuestionnaire {
+                        popUpTo(ENTRYPOINT_ROUTE) { inclusive = true }
+                    }
+                } else {
+                    val profileUuid = try {
+                        java.util.UUID.fromString(savedProfileId)
+                    } catch (e: IllegalArgumentException) {
+                        null
+                    }
+                    if (profileUuid != null) {
+                        navController.navigateToHomeScreen(profileUuid) {
+                            popUpTo(ENTRYPOINT_ROUTE) { inclusive = true }
+                        }
+                    } else {
+                        navController.navigateToQuestionnaire {
+                            popUpTo(ENTRYPOINT_ROUTE) { inclusive = true }
+                        }
+                    }
                 }
             }
         }

--- a/core/src/main/java/com/uoa/core/utils/Constants.kt
+++ b/core/src/main/java/com/uoa/core/utils/Constants.kt
@@ -7,5 +7,6 @@ class Constants {
         const val DRIVER_EMAIL_ID = "driver_email_id"
         const val TRIP_ID = "trip_id"
         const val QUESTIONNAIRE_COMPLETED = "questionnaireCompleted"
+        const val LAST_QUESTIONNAIRE_DAY = "lastQuestionnaireDay"
     }
 }


### PR DESCRIPTION
## Summary
- add `LAST_QUESTIONNAIRE_DAY` preference key
- show the questionnaire only once per day in `EntryPointNavigation`
- clarify behaviour in README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685f3199c7fc8332b5bd996731a01d85