### PR TITLE
Centralize navigation routes to avoid module cycles

### DIFF
--- a/app/src/main/java/com/uoa/safedriveafrica/DaAppState.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/DaAppState.kt
@@ -23,9 +23,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import com.uoa.safedriveafrica.presentation.daappnavigation.TopLevelDestinations
-import com.uoa.nlgengine.presentation.ui.reportNavigation.FILTER_SCREEN_ROUTE
-import com.uoa.nlgengine.presentation.ui.reportNavigation.REPORT_SCREEN_ROUTE
-import com.uoa.sensor.presentation.ui.sensornavigation.SENSOR_CONTROL_SCREEN_ROUTE
+import com.uoa.core.utils.FILTER_SCREEN_ROUTE
+import com.uoa.core.utils.REPORT_SCREEN_ROUTE
+import com.uoa.core.utils.SENSOR_CONTROL_SCREEN_ROUTE
 import android.app.Application
 import androidx.compose.ui.platform.LocalContext
 import com.uoa.core.utils.ENTRYPOINT_ROUTE

--- a/core/src/main/java/com/uoa/core/utils/Router.kt
+++ b/core/src/main/java/com/uoa/core/utils/Router.kt
@@ -9,3 +9,8 @@ const val ONBOARDING_SCREEN_ROUTE = "onboardingScreen"
 const val ALCOHOL_QUESTIONNAIRE_ROUTE = "alcoholQuestionnaire"
 const val DRIVER_PROFILE_ID = "profileId"
 const val HOME_SCREEN_ROUTE = "homeScreen/{$DRIVER_PROFILE_ID}"
+
+// Routes from feature modules
+const val SENSOR_CONTROL_SCREEN_ROUTE = "sensorControlScreen"
+const val FILTER_SCREEN_ROUTE = "filterScreen"
+const val REPORT_SCREEN_ROUTE = "reportScreen"

--- a/driverprofile/src/main/java/com/uoa/driverprofile/presentation/ui/screens/HomeScreen.kt
+++ b/driverprofile/src/main/java/com/uoa/driverprofile/presentation/ui/screens/HomeScreen.kt
@@ -42,8 +42,8 @@ import com.uoa.core.utils.Constants.Companion.PREFS_NAME
 import com.uoa.driverprofile.presentation.ui.composables.TipList
 import com.uoa.driverprofile.presentation.ui.navigation.navigateToDrivingTipDetailsScreen
 import com.uoa.driverprofile.presentation.viewmodel.DrivingTipsViewModel
-import com.uoa.sensor.presentation.ui.sensornavigation.SENSOR_CONTROL_SCREEN_ROUTE
-import com.uoa.nlgengine.presentation.ui.reportNavigation.FILTER_SCREEN_ROUTE
+import com.uoa.core.utils.SENSOR_CONTROL_SCREEN_ROUTE
+import com.uoa.core.utils.FILTER_SCREEN_ROUTE
 import java.util.UUID
 
 

--- a/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/reportNavigation/FilterScreenNavigation.kt
+++ b/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/reportNavigation/FilterScreenNavigation.kt
@@ -4,8 +4,8 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.uoa.nlgengine.presentation.ui.FilterScreenRoute
+import com.uoa.core.utils.FILTER_SCREEN_ROUTE
 
-const val FILTER_SCREEN_ROUTE = "filterScreen"
 
 fun NavGraphBuilder.filterScreen(navController: NavController) {
     composable(FILTER_SCREEN_ROUTE) {

--- a/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/reportNavigation/ReportScreenNavigation.kt
+++ b/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/reportNavigation/ReportScreenNavigation.kt
@@ -8,8 +8,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.uoa.nlgengine.presentation.ui.ReportScreenRoute
 import com.uoa.core.utils.PeriodType
+import com.uoa.core.utils.REPORT_SCREEN_ROUTE
 
-const val REPORT_SCREEN_ROUTE = "reportScreen"
 
 
 fun NavGraphBuilder.reportScreen(navController: NavController) {

--- a/sensor/src/main/java/com/uoa/sensor/presentation/ui/sensornavigation/SensorNavigationScreen.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/ui/sensornavigation/SensorNavigationScreen.kt
@@ -7,10 +7,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.uoa.sensor.presentation.ui.SensorControlScreenRoute
+import com.uoa.core.utils.SENSOR_CONTROL_SCREEN_ROUTE
 import com.uoa.sensor.presentation.viewModel.SensorViewModel
 import com.uoa.sensor.presentation.viewModel.TripViewModel
 
-const val SENSOR_CONTROL_SCREEN_ROUTE = "sensorControlScreen"
 
 @RequiresApi(Build.VERSION_CODES.Q)
 fun NavGraphBuilder.sensorControlScreen(navController: NavController) {


### PR DESCRIPTION
## Summary
- move navigation route constants into `core` module
- update feature modules and app to import routes from `core`
- prevent potential circular dependencies by keeping `driverprofile` free of sensor and nlgengine dependencies

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685f384c0d2c8332a83b04ff224d36e6