### PR TITLE
Fix EntryPointNavigation compile issue

### DIFF
--- a/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/EntryPointNavigation.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/EntryPointNavigation.kt
@@ -52,7 +52,7 @@ fun NavGraphBuilder.entryPointScreen(
                         null
                     }
                     if (profileUuid != null) {
-                        navController.navigateToHomeScreen(profileUuid) {
+                        navController.navigate("homeScreen/$profileUuid") {
                             popUpTo(ENTRYPOINT_ROUTE) { inclusive = true }
                         }
                     } else {


### PR DESCRIPTION
## Summary
- fix incorrect call to navigateToHomeScreen

## Testing
- `sh ./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*
- `sh ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685f4eec8d3883328ec29cef364ddd7f