### PR TITLE
Fix manifest package

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" >
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.uoa.safedriveafrica" >
 
     <application
         android:name=".App"


### PR DESCRIPTION
## Summary
- specify app package in manifest to avoid wrong activity lookup

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685fb0a21cbc8332b9430ca25290fbbd