### PR TITLE
Fix trip creation naming and add internet permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.uoa.safedriveafrica" >
 
+    <!-- Required for all network operations -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/core/src/main/java/com/uoa/core/apiServices/models/tripModels/TipResponse.kt
+++ b/core/src/main/java/com/uoa/core/apiServices/models/tripModels/TipResponse.kt
@@ -1,15 +1,16 @@
 package com.uoa.core.apiServices.models.tripModels
 
+import com.google.gson.annotations.SerializedName
 import java.util.UUID
 
 // TripResponse.kt
 data class TripResponse(
     val id: UUID,
     val driverProfileId: UUID,
-    val start_date: String,
-    val end_date: String?,
-    val start_time: Long,
-    val end_time: Long?,
+    @SerializedName("startDate") val startDate: String,
+    @SerializedName("endDate") val endDate: String?,
+    @SerializedName("startTime") val startTime: Long,
+    @SerializedName("endTime") val endTime: Long?,
     val synced: Boolean,
-    val influence: String?=null
+    val influence: String? = null
 )

--- a/core/src/main/java/com/uoa/core/apiServices/models/tripModels/TripCreate.kt
+++ b/core/src/main/java/com/uoa/core/apiServices/models/tripModels/TripCreate.kt
@@ -7,12 +7,14 @@ import java.util.UUID
 data class TripCreate(
     val id: UUID,
     val driverProfileId: UUID?,
-    @SerializedName("start_date")
-    val start_date: String?=null, // ISO 8601 format
-    @SerializedName("end_date")
-    val end_date: String?=null, // Optional
-    val start_time: Long?=null,
-    val end_time: Long?=null, // Optional
+    @SerializedName("startDate")
+    val startDate: String? = null, // ISO 8601 format
+    @SerializedName("endDate")
+    val endDate: String? = null, // Optional
+    @SerializedName("startTime")
+    val startTime: Long? = null,
+    @SerializedName("endTime")
+    val endTime: Long? = null, // Optional
     val sync: Boolean,
     val influence: String
 )

--- a/core/src/main/java/com/uoa/core/apiServices/workManager/UploadAllDataWorker.kt
+++ b/core/src/main/java/com/uoa/core/apiServices/workManager/UploadAllDataWorker.kt
@@ -334,10 +334,10 @@ class UploadAllDataWorker @AssistedInject constructor(
             TripCreate(
                 id = trip.id,
                 driverProfileId = trip.driverPId,
-                start_date = trip.startDate?.let { DateConversionUtils.dateToString(it) },
-                end_date = trip.endDate?.let { DateConversionUtils.dateToString(it) },
-                start_time = trip.startTime,
-                end_time = trip.endTime,
+                startDate = trip.startDate?.let { DateConversionUtils.dateToString(it) },
+                endDate = trip.endDate?.let { DateConversionUtils.dateToString(it) },
+                startTime = trip.startTime,
+                endTime = trip.endTime,
                 sync = true,
                 influence = trip.influence!!
             )
@@ -453,10 +453,10 @@ class UploadAllDataWorker @AssistedInject constructor(
             val tripUpdate = TripCreate(
                 id = trip.id,
                 driverProfileId = trip.driverPId,
-                start_date = isoStartDate,
-                end_date = isoEndDate,
-                start_time = trip.startTime,
-                end_time = trip.endTime,
+                startDate = isoStartDate,
+                endDate = isoEndDate,
+                startTime = trip.startTime,
+                endTime = trip.endTime,
                 sync = true, // Indicate that after upload, sync should be true
                 influence = trip.influence!!
             )

--- a/core/src/main/java/com/uoa/core/utils/LocalToRemoteVMappers.kt
+++ b/core/src/main/java/com/uoa/core/utils/LocalToRemoteVMappers.kt
@@ -37,24 +37,24 @@ fun Trip.toTripCreate(): TripCreate {
     val isoStartDate = dateFormatUTC.format(startDate!!)
     val isoEndDate = endDate?.let { dateFormatUTC.format(it) }
     return TripCreate(
-        id= id,
+        id = id,
         driverProfileId = driverPId,
-        start_date = isoStartDate,
-        end_date = isoEndDate!!,
-        start_time = startTime,
-        end_time = endTime,
+        startDate = isoStartDate,
+        endDate = isoEndDate!!,
+        startTime = startTime,
+        endTime = endTime,
         sync = sync,
-        influence=influence!!
+        influence = influence!!
     )
 }
 
 fun TripCreate.toTrip(): Trip {
-    val parsedStartDate = dateFormatUTC.parse(start_date)
-    val parsedEndDate = end_date.let { dateFormatUTC.parse(it) }
+    val parsedStartDate = dateFormatUTC.parse(startDate)
+    val parsedEndDate = endDate.let { dateFormatUTC.parse(it) }
     return Trip(
         driverPId = driverProfileId,
-        startTime = start_time!!,
-        endTime = end_time,
+        startTime = startTime!!,
+        endTime = endTime,
         startDate = parsedStartDate,
         endDate = parsedEndDate,
         id = UUID.randomUUID(), // Adjust as needed if you have a way to set the ID

--- a/sensor/src/main/java/com/uoa/sensor/presentation/viewModel/TripViewModel.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/viewModel/TripViewModel.kt
@@ -72,10 +72,10 @@ class TripViewModel @Inject constructor(
             val tripCreate = TripCreate(
                 id = tripId,
                 driverProfileId = driverProfileId,
-                start_date = isoStartDate,
-                end_date = null,
-                start_time = startTime,
-                end_time = null,
+                startDate = isoStartDate,
+                endDate = null,
+                startTime = startTime,
+                endTime = null,
                 influence = "",
                 sync = true
             )
@@ -224,10 +224,10 @@ class TripViewModel @Inject constructor(
         val tripCreate = TripCreate(
             id = updatedTrip.id,
             driverProfileId = updatedTrip.driverPId,
-            start_date = isoStartDate,
-            end_date = isoEndDate,
-            start_time = updatedTrip.startTime, // BigInteger on server
-            end_time = endTime,                 // Current time as BigInteger
+            startDate = isoStartDate,
+            endDate = isoEndDate,
+            startTime = updatedTrip.startTime, // BigInteger on server
+            endTime = endTime,                 // Current time as BigInteger
             influence = influenceLabel,
             sync = true
         )

--- a/sensor/src/main/java/com/uoa/sensor/services/VehicleMovementServiceUpdated.kt
+++ b/sensor/src/main/java/com/uoa/sensor/services/VehicleMovementServiceUpdated.kt
@@ -172,7 +172,16 @@ class VehicleMovementServiceUpdate : LifecycleService() {
 
             // Remote create
             val isoDate = utcIso(startTime)
-            val payload = TripCreate(tripId, driverProfileId, isoDate, null, startTime, null,true, "")
+            val payload = TripCreate(
+                id = tripId,
+                driverProfileId = driverProfileId,
+                startDate = isoDate,
+                endDate = null,
+                startTime = startTime,
+                endTime = null,
+                sync = true,
+                influence = ""
+            )
             tripApiRepository.createTrip(payload)
 
             // Update state flows
@@ -215,10 +224,10 @@ class VehicleMovementServiceUpdate : LifecycleService() {
             val payload = TripCreate(
                 id = tripId,
                 driverProfileId = localTrip.driverPId,
-                start_date = utcIso(localTrip.startDate!!.time),
-                end_date = utcIso(System.currentTimeMillis()),
-                start_time = localTrip.startTime,
-                end_time = System.currentTimeMillis(),
+                startDate = utcIso(localTrip.startDate!!.time),
+                endDate = utcIso(System.currentTimeMillis()),
+                startTime = localTrip.startTime,
+                endTime = System.currentTimeMillis(),
                 influence = label,
                 sync = true
             )


### PR DESCRIPTION
## Summary
- add missing INTERNET permission to main manifest
- align TripCreate and TripResponse field names with backend
- update mappers, workers and view models for new names

## Testing
- `./gradlew test` *(fails: Unable to download gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6862fa7b3cdc8332a9ab91d958c538d0