### PR TITLE
Ensure full culturally relevant driving reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,12 @@ Privacy Policy link – `https://datahub.safedriveafrica.com/privacy`
 
 See `DisclaimerScreen.kt` lines 95‑101 for the implementation.
 
+## Behavioural and persuasive design
+
+The driving reports now employ culturally familiar language for Nigerian drivers while remaining accessible to Cameroonian and Ghanaian users. The report prompt integrates behaviour‑change theories to encourage safer driving:
+
+- **Theory of Planned Behavior** – emphasises attitudes toward safety, the influence of friends and family (subjective norms), and the driver's ability to change (perceived behavioural control).
+- **Cialdini's Principles** – uses social proof to show that other local drivers are improving and highlights potential losses (loss aversion) from risky habits.
+
+By weaving these elements into a concise 150–180 word narrative, the report becomes more persuasive and easier to read, helping drivers absorb the guidance without feeling overwhelmed.
+

--- a/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/ReportScreen.kt
+++ b/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/ReportScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -174,10 +175,16 @@ fun ReportScreen(
                             )
                             Text(
                                 text = reportContent,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 8.dp),
                                 style = MaterialTheme.typography.bodyLarge.copy(
-                                    lineHeight = 24.sp,
+                                    fontSize = 16.sp,
+                                    lineHeight = 22.sp,
                                     color = Color.Black
-                                )
+                                ),
+                                textAlign = TextAlign.Justify,
+                                maxLines = Int.MAX_VALUE
                             )
                         }
                     }

--- a/nlgengine/src/main/java/com/uoa/nlgengine/presentation/viewmodel/NLGEngineViewModel.kt
+++ b/nlgengine/src/main/java/com/uoa/nlgengine/presentation/viewmodel/NLGEngineViewModel.kt
@@ -340,13 +340,13 @@ class NLGEngineViewModel @Inject constructor(
 
         return buildString {
             append("$periodText\n\n")
-            append("You are a Nigerian driving safety specialist. Based on the provided data, generate a concise (150 words) personalised driving behavior report for the driver that:\n")
-            append("• Recognizes positive driving habits.\n")
-            append("• Suggests actionable safety improvements without harsh criticism.\n")
-            append("• Uses the given numeric data for offences, fines, and laws (decoded from Base64 JSON).\n")
-            append("• References specific dates and a location for the most prominent unsafe behavior.\n")
-            append("• Integrates key aspects of the Theory of Planned Behavior in plain language.\n")
-            append("• Signs off as 'Your Driving Safety Specialist Agent'.\n\n")
+            append("You are a friendly driving safety coach speaking mainly to Nigerian drivers, while remaining understandable in Cameroon and Ghana. Using the statistics below, craft a complete 150-180 word report that never ends abruptly:\n")
+            append("• Use culturally familiar terms and relatable examples from West Africa.\n")
+            append("• Praise good habits and offer actionable, persuasive tips for improvement.\n")
+            append("• Apply elements from the Theory of Planned Behavior—attitudes, subjective norms and perceived behavioural control—and Cialdini's principles like Social Proof and Loss Aversion.\n")
+            append("• Reference the exact numbers, dates and road location of the most frequent unsafe behaviour.\n")
+            append("• Keep the tone supportive and sign off as 'Your Driving Safety Specialist Agent'.\n")
+            append("• Ensure the response forms a complete narrative, not a list of bullets or an unfinished sentence.\n\n")
             append("Report Statistics:\n")
             append("Total Unsafe Behaviors: ${reportStatistics.totalIncidences}\n")
             if (reportStatistics.mostFrequentUnsafeBehaviour != null &&

--- a/nlgengine/src/main/java/com/uoa/nlgengine/presentation/viewmodel/chatgpt/ChatGPTViewModel.kt
+++ b/nlgengine/src/main/java/com/uoa/nlgengine/presentation/viewmodel/chatgpt/ChatGPTViewModel.kt
@@ -230,30 +230,29 @@ fun promptChatGPTForResponse(prompt: String, periodType: PeriodType, driverProfi
                     Message(role = "user", content = prompt)
                 )
 
-                // Reduce token count by using a lower `maxTokens`
                 val requestBody = RequestBody(
                     model = "gpt-4-turbo",
                     messages = messages,
-                    maxTokens = 150, // Reduced from 200
+                    maxTokens = 350,
                     temperature = 0f
                 )
 
                 val response = nlgEngineRepository.sendChatGPTPrompt(requestBody)
                 val initialReply = response.choices.firstOrNull()?.message?.content ?: ""
 
-                // Reflection Step - Use a shorter request
+                // Reflection step ensures final reply is coherent and complete
                 messages.add(Message(role = "assistant", content = initialReply))
                 messages.add(
                     Message(
                         role = "user",
-                        content = "Revise the response if needed to fully align with data. Do not exceed 200 words."
+                        content = "Revise the response to fully match the data and deliver a complete persuasive report of 150-180 words."
                     )
                 )
 
                 val reflectionRequestBody = RequestBody(
-                    model = "gpt-4o-mini", // Use a smaller model
+                    model = "gpt-4o-mini",
                     messages = messages,
-                    maxTokens = 200, // Reduced from 300
+                    maxTokens = 350,
                     temperature = 0f
                 )
 


### PR DESCRIPTION
## Summary
- Refactor driving-report prompt to include culturally familiar Nigerian-focused language and behavioural change principles
- Raise ChatGPT token limits and add reflection to avoid truncated reports
- Improve report screen readability so the entire response displays

## Testing
- `bash ./gradlew :nlgengine:test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6898a705ca088332aed72aed76c95f65