### PR TITLE
Refactor AI model input schema

### DIFF
--- a/core/src/main/java/com/uoa/core/apiServices/models/aiModelInputModels/AIModelInputCreate.kt
+++ b/core/src/main/java/com/uoa/core/apiServices/models/aiModelInputModels/AIModelInputCreate.kt
@@ -1,15 +1,16 @@
 package com.uoa.core.apiServices.models.aiModelInputModels
 
+import com.google.gson.annotations.SerializedName
 import java.util.UUID
 
 // AIModelInputCreate.kt
 data class AIModelInputCreate(
     val id: UUID,
     val trip_id: UUID,
-    val driver_profile_id: UUID,
+    @SerializedName("driver_profile_id")
+    val driverProfileId: UUID,
     val timestamp: String, // ISO 8601 format
-    val startTimeStamp: String, // Iso 8601 format
-    val endTimeStamp: String,
+    val start_time: Long,
     val date: String, // ISO 8601 format
     val hour_of_day_mean: Double,
     val day_of_week_mean: Double,

--- a/core/src/main/java/com/uoa/core/apiServices/workManager/UploadAllDataWorker.kt
+++ b/core/src/main/java/com/uoa/core/apiServices/workManager/UploadAllDataWorker.kt
@@ -687,10 +687,9 @@ class UploadAllDataWorker @AssistedInject constructor(
                 AIModelInputCreate(
                     id = input.id,
                     trip_id = input.tripId,
-                    driver_profile_id = input.driverProfileId,
+                    driverProfileId = input.driverProfileId,
                     timestamp = DateConversionUtils.longToTimestampString(input.timestamp),
-                    startTimeStamp = DateConversionUtils.longToTimestampString(input.startTimestamp),
-                    endTimeStamp = DateConversionUtils.longToTimestampString(input.endTimestamp),
+                    start_time = input.startTimestamp,
                     date = formattedDate ?: "",
                     hour_of_day_mean = input.hourOfDayMean,
                     day_of_week_mean = input.dayOfWeekMean.toDouble(),


### PR DESCRIPTION
## Summary
- rename driver_profile_id to driverProfileId with @SerializedName mapping
- use numeric start_time and drop endTimeStamp from AIModelInputCreate
- construct AIModelInputCreate in UploadAllDataWorker with driverProfileId and start_time

## Testing
- `gradle test` *(fails: The file '/workspace/driveafrica/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68997a5fcc048332a138dfae6796274f