### PR TITLE
Check questionnaire timestamp daily

### DIFF
--- a/alcoholquestionnaire/src/main/java/com/uoa/alcoholquestionnaire/presentation/ui/screens/AlcoholQuestionnaireScreenRoute.kt
+++ b/alcoholquestionnaire/src/main/java/com/uoa/alcoholquestionnaire/presentation/ui/screens/AlcoholQuestionnaireScreenRoute.kt
@@ -12,8 +12,11 @@ import androidx.navigation.NavController
 import com.uoa.alcoholquestionnaire.presentation.viewmodel.QuestionnaireViewModel
 import com.uoa.core.utils.ALCOHOL_QUESTIONNAIRE_ROUTE
 import com.uoa.core.utils.Constants.Companion.DRIVER_PROFILE_ID
+import com.uoa.core.utils.Constants.Companion.LAST_QUESTIONNAIRE_DAY
 import com.uoa.core.utils.Constants.Companion.PREFS_NAME
 import com.uoa.core.utils.Resource
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
@@ -34,6 +37,9 @@ fun AlcoholQuestionnaireScreenRoute(
                 Log.e("Navigation", uploadState.toString())
                 val savedProfileId = prefs.getString(DRIVER_PROFILE_ID, null)
                 val profileUuid = UUID.fromString(savedProfileId ?: return@LaunchedEffect)
+
+                val today = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+                prefs.edit().putString(LAST_QUESTIONNAIRE_DAY, today).apply()
 
                 // Navigate to home screen after success
                 navController.navigate("homeScreen/${profileUuid}") {

--- a/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/EntryPointNavigation.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/EntryPointNavigation.kt
@@ -41,7 +41,6 @@ fun NavGraphBuilder.entryPointScreen(
             } else {
                 val shouldShowQuestionnaire = lastDay != today
                 if (shouldShowQuestionnaire) {
-                    prefs.edit().putString(LAST_QUESTIONNAIRE_DAY, today).apply()
                     navController.navigateToQuestionnaire {
                         popUpTo(ENTRYPOINT_ROUTE) { inclusive = true }
                     }


### PR DESCRIPTION
## Summary
- Check last questionnaire date in entry point and send user to questionnaire only when needed
- Record today's date after questionnaire submission to avoid repeated prompts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a248d088c83328db59712142a356c