### PR TITLE
Improve home UI and add icons & logo

### DIFF
--- a/alcoholquestionnaire/src/main/java/com/uoa/alcoholquestionnaire/presentation/ui/screens/AlcoholQuestionnaireScreen.kt
+++ b/alcoholquestionnaire/src/main/java/com/uoa/alcoholquestionnaire/presentation/ui/screens/AlcoholQuestionnaireScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -77,6 +80,8 @@ fun AlcoholQuestionnaireScreen(
             Text("Alcohol Consumption Questionnaire", fontSize = 18.sp)
             Spacer(modifier = Modifier.height(2.dp))
             Button(onClick = onCancel) {
+                Icon(Icons.Filled.Close, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
                 Text("Cancel")
             }
         }
@@ -215,6 +220,8 @@ fun AlcoholQuestionnaireScreen(
             },
             modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
+            Icon(Icons.Filled.Check, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
             Text("Submit")
         }
     }

--- a/app/src/main/java/com/uoa/safedriveafrica/DaApp.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/DaApp.kt
@@ -2,11 +2,14 @@ package com.uoa.safedriveafrica
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -23,6 +26,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -78,7 +82,16 @@ fun DAApp(appState: DAAppState) {
 @Composable
 fun DATopBar(appState: DAAppState) {
     TopAppBar(
-        title = { Text(stringResource(id = com.uoa.dbda.R.string.app_name)) },
+        title = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Image(
+                    painter = painterResource(id = com.uoa.core.R.mipmap.ic_sda_ic_app),
+                    contentDescription = null
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(id = com.uoa.dbda.R.string.app_name))
+            }
+        },
         navigationIcon = {
             if (appState.canNavigateBack()) {
                 IconButton(onClick = { appState.navController.popBackStack() }) {

--- a/app/src/main/java/com/uoa/safedriveafrica/ui/splashscreens/DisclaimerScreen.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/ui/splashscreens/DisclaimerScreen.kt
@@ -3,9 +3,12 @@ package com.uoa.safedriveafrica.ui.splashscreens
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -88,6 +91,8 @@ fun DisclaimerScreen(
                 Spacer(modifier = Modifier.height(32.dp))
                 val context = LocalContext.current
                 Button(onClick = onContinue) {
+                    Icon(Icons.Filled.ArrowForward, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
                     Text(text = "Continue")
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/uoa/safedriveafrica/ui/splashscreens/WelcomeScreen.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/ui/splashscreens/WelcomeScreen.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -97,6 +100,8 @@ fun WelcomeScreen(
                 )
                 Spacer(modifier = Modifier.height(5.dp))
                 Button(onClick = onContinue) {
+                    Icon(Icons.Filled.ArrowForward, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
                     Text(text = "Continue")
                 }
             }

--- a/core/src/main/java/com/uoa/core/ui/DAAppTopNavBar.kt
+++ b/core/src/main/java/com/uoa/core/ui/DAAppTopNavBar.kt
@@ -9,6 +9,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.Image
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Person
@@ -19,6 +22,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -37,26 +42,35 @@ fun DAAppTopNavBar(
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(start = 5.dp)
+                    .padding(start = 5.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 IconButton(onClick = navigateBack) {
                     Icon(
-                        imageVector = Icons.Default.ArrowBack,  // Use Default if AutoMirrored is not available
+                        imageVector = Icons.Default.ArrowBack,
                         contentDescription = "Back",
                         tint = Color.White
                     )
                 }
 
-                // Making the Text clickable to navigate to the home screen
-                Text(
+                Row(
                     modifier = Modifier
                         .weight(1f)
                         .clickable { navigateHome() }
                         .padding(start = 10.dp),
-                    text = "Safe Drive Africa",
-                    color = Color.White,
-                    style = MaterialTheme.typography.headlineSmall  // Updated for consistency with Compose Material Typography
-                )
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Image(
+                        painter = painterResource(id = R.mipmap.ic_sda_ic_app),
+                        contentDescription = "App Logo"
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Safe Drive Africa",
+                        color = Color.White,
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+                }
 
                 IconButton(onClick = { /*TODO: Handle user icon click*/ }) {
                     Icon(

--- a/driverprofile/src/main/java/com/uoa/driverprofile/presentation/ui/composables/TipList.kt
+++ b/driverprofile/src/main/java/com/uoa/driverprofile/presentation/ui/composables/TipList.kt
@@ -1,8 +1,7 @@
 package com.uoa.driverprofile.presentation.ui.composables
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import com.uoa.core.model.DrivingTip
@@ -14,10 +13,10 @@ fun TipList(
     source: String,
     onDrivingTipClick: (UUID) -> Unit
 ) {
-    LazyColumn(
+    Column(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        items(tips) { tip ->
+        tips.forEach { tip ->
             TipCard(
                 tip = tip,
                 source = source,

--- a/driverprofile/src/main/java/com/uoa/driverprofile/presentation/ui/screens/DriverProfileCreationScreen.kt
+++ b/driverprofile/src/main/java/com/uoa/driverprofile/presentation/ui/screens/DriverProfileCreationScreen.kt
@@ -3,9 +3,14 @@ package com.uoa.driverprofile.presentation.ui.screens
 import android.content.Context
 import android.util.Log
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -76,6 +81,8 @@ fun DriverProfileCreationScreen(
             modifier = Modifier.padding(top = 16.dp),
             enabled = !isError
         ) {
+            Icon(Icons.Filled.PersonAdd, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
             Text("Create Profile")
         }
     }

--- a/driverprofile/src/main/java/com/uoa/driverprofile/presentation/ui/screens/HomeScreen.kt
+++ b/driverprofile/src/main/java/com/uoa/driverprofile/presentation/ui/screens/HomeScreen.kt
@@ -3,24 +3,20 @@ import android.content.Context
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresExtension
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.scrollable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Assessment
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ListItem
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,16 +24,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.test.hasText
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.uoa.core.model.DrivingTip
 import com.uoa.core.utils.Constants.Companion.DRIVER_EMAIL_ID
-import com.uoa.core.utils.Constants.Companion.DRIVER_PROFILE_ID
 import com.uoa.core.utils.Constants.Companion.PREFS_NAME
 import com.uoa.driverprofile.presentation.ui.composables.TipList
 import com.uoa.driverprofile.presentation.ui.navigation.navigateToDrivingTipDetailsScreen
@@ -61,9 +52,8 @@ fun HomeScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .fillMaxHeight()
+            .verticalScroll(rememberScrollState())
             .padding(16.dp)
-
     ) {
         Text(
             text = "Hi ${savedEmail}!\nYour Driving Tips Today",
@@ -100,10 +90,14 @@ fun HomeScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
         Button(onClick = onRecordTripClick, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Filled.PlayArrow, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
             Text(text = "Record Trip")
         }
         Spacer(modifier = Modifier.height(8.dp))
         Button(onClick = onViewReportsClick, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Filled.Assessment, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
             Text(text = "View Reports")
         }
     }

--- a/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/FilterScreen.kt
+++ b/nlgengine/src/main/java/com/uoa/nlgengine/presentation/ui/FilterScreen.kt
@@ -9,9 +9,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Assessment
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.EditCalendar
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Today
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -94,14 +105,14 @@ fun FilterScreen(
                     .fillMaxWidth()
                     .horizontalScroll(rememberScrollState())
             ) {
-                PeriodButton("Last Trip") {
+                PeriodButton("Last Trip", Icons.Filled.History) {
                     periodType = PeriodType.LAST_TRIP
                     startDate = null
                     endDate = null
                     displayStartDate = ""
                     displayEndDate = ""
                 }
-                PeriodButton("Today") {
+                PeriodButton("Today", Icons.Filled.Today) {
                     val todayStart = Calendar.getInstance().apply {
                         set(Calendar.HOUR_OF_DAY, 0)
                         set(Calendar.MINUTE, 0)
@@ -117,7 +128,7 @@ fun FilterScreen(
                     updateDates(todayStart, todayEnd)
                     periodType = PeriodType.TODAY
                 }
-                PeriodButton("This Week") {
+                PeriodButton("This Week", Icons.Filled.DateRange) {
                     val calendar = Calendar.getInstance()
                     calendar.set(Calendar.DAY_OF_WEEK, calendar.firstDayOfWeek)
                     calendar.set(Calendar.HOUR_OF_DAY, 0)
@@ -134,7 +145,7 @@ fun FilterScreen(
                     updateDates(weekStart, weekEnd)
                     periodType = PeriodType.THIS_WEEK
                 }
-                PeriodButton("Last Week") {
+                PeriodButton("Last Week", Icons.Filled.Event) {
                     val calendar = Calendar.getInstance()
                     calendar.set(Calendar.DAY_OF_WEEK, calendar.firstDayOfWeek)
                     calendar.add(Calendar.WEEK_OF_YEAR, -1)
@@ -152,7 +163,7 @@ fun FilterScreen(
                     updateDates(lastWeekStart, lastWeekEnd)
                     periodType = PeriodType.LAST_WEEK
                 }
-                PeriodButton("Custom Period") {
+                PeriodButton("Custom Period", Icons.Filled.EditCalendar) {
                     displayStartDate = ""
                     displayEndDate = ""
                     startDate = null
@@ -182,7 +193,7 @@ fun FilterScreen(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                ActionButton("Clear All") {
+                ActionButton("Clear All", Icons.Filled.Clear) {
                     displayStartDate = ""
                     displayEndDate = ""
                     startDate = null
@@ -191,7 +202,7 @@ fun FilterScreen(
                 }
 
 //                To be activate in second phase
-                ActionButton("Generate Report") {
+                ActionButton("Generate Report", Icons.Filled.Assessment) {
                     val selectedStartDate = startDate
                     val selectedEndDate = endDate
 
@@ -208,11 +219,13 @@ fun FilterScreen(
 
 
 @Composable
-fun PeriodButton(text: String, onClick: () -> Unit) {
+fun PeriodButton(text: String, icon: ImageVector, onClick: () -> Unit) {
     Button(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(containerColor = Color.LightGray)
     ) {
+        Icon(icon, contentDescription = null, tint = Color.Blue)
+        Spacer(modifier = Modifier.width(4.dp))
         Text(text = text, color = Color.Blue)
     }
 }
@@ -232,11 +245,13 @@ fun setPeriod(start: Date, end: Date, setDisplayStartDate: (String) -> Unit, set
 
 
 @Composable
-fun ActionButton(text: String, onClick: () -> Unit) {
+fun ActionButton(text: String, icon: ImageVector, onClick: () -> Unit) {
     Button(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(containerColor = Color.Blue)
     ) {
+        Icon(icon, contentDescription = null, tint = Color.White)
+        Spacer(modifier = Modifier.width(4.dp))
         Text(text = text, color = Color.White)
     }
 }

--- a/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreenUpdate.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreenUpdate.kt
@@ -8,7 +8,11 @@ import android.os.Looper
 import android.annotation.SuppressLint
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -132,6 +136,8 @@ fun SensorControlScreenUpdate(
                 onClick = { permissionState.launchMultiplePermissionRequest() },
                 enabled = true
             ) {
+                Icon(Icons.Filled.CheckCircle, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
                 Text("Grant Permissions")
             }
             return@Column
@@ -224,6 +230,8 @@ fun SensorControlScreenUpdate(
                 context.stopService(Intent(context, VehicleMovementServiceUpdate::class.java))
                 serviceStarted = false
             }) {
+                Icon(Icons.Filled.Stop, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
                 Text("Stop Monitoring")
             }
         }


### PR DESCRIPTION
## Summary
- Make tips HomeScreen vertically scrollable and add icons to Record Trip and View Reports buttons
- Show app logo before "Safe Drive Africa" in top bars
- Add appropriate icons to various buttons across the app for better UX

## Testing
- `./gradlew test --offline` *(fails: Unable to tunnel through proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a6a2e47908332981d3fccaba2b45f