### PR TITLE
Fix crash from adaptive icon in Compose top bars

### DIFF
--- a/app/src/main/java/com/uoa/safedriveafrica/DaApp.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/DaApp.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -85,7 +86,7 @@ fun DATopBar(appState: DAAppState) {
         title = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Image(
-                    painter = painterResource(id = com.uoa.core.R.mipmap.ic_sda_ic_app),
+                    painter = painterResource(id = com.uoa.core.R.drawable.sda_2),
                     contentDescription = null
                 )
                 Spacer(modifier = Modifier.width(8.dp))

--- a/core/src/main/java/com/uoa/core/ui/DAAppTopNavBar.kt
+++ b/core/src/main/java/com/uoa/core/ui/DAAppTopNavBar.kt
@@ -61,7 +61,7 @@ fun DAAppTopNavBar(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Image(
-                        painter = painterResource(id = R.mipmap.ic_sda_ic_app),
+                        painter = painterResource(id = R.drawable.sda_2),
                         contentDescription = "App Logo"
                     )
                     Spacer(modifier = Modifier.width(8.dp))


### PR DESCRIPTION
## Summary
- Use standard drawable `sda_2` instead of adaptive `mipmap` icon to avoid runtime crash in Compose top bar
- Add missing `dp` import

## Testing
- `gradle assembleDebug` *(fails: The file '/workspace/driveafrica/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689a7b12770883329cfcc69874c080db