### PR TITLE
Reset vehicle movement flag when leaving vehicle mode

### DIFF
--- a/sensor/src/main/java/com/uoa/sensor/hardware/MotionDetectionFFT.kt
+++ b/sensor/src/main/java/com/uoa/sensor/hardware/MotionDetectionFFT.kt
@@ -279,6 +279,7 @@ class MotionDetectionFFT @Inject constructor(
         SCOPE.launch {
             stateRepo.updateMovementType("walking")
             stateRepo.updateMovementStatus(true)
+            stateRepo.updateVehicleMovementStatus(false)
         }
     }
 
@@ -294,6 +295,7 @@ class MotionDetectionFFT @Inject constructor(
         SCOPE.launch {
             stateRepo.updateMovementType("running")
             stateRepo.updateMovementStatus(true)
+            stateRepo.updateVehicleMovementStatus(false)
         }
     }
     private fun transitionToVehicle(now: Long) {
@@ -322,6 +324,7 @@ class MotionDetectionFFT @Inject constructor(
         listeners.forEach { it.onMotionStopped() }
         SCOPE.launch {
             stateRepo.updateMovementStatus(false)
+            stateRepo.updateVehicleMovementStatus(false)
             stateRepo.updateMovementType("stationary") }
     }
 

--- a/sensor/src/test/java/com/uoa/sensor/hardware/MotionDetectionFFTTest.kt
+++ b/sensor/src/test/java/com/uoa/sensor/hardware/MotionDetectionFFTTest.kt
@@ -1,0 +1,53 @@
+package com.uoa.sensor.hardware
+
+import com.uoa.core.database.entities.FFTFeatureDao
+import com.uoa.sensor.repository.SensorDataColStateRepository
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+/**
+ * Verifies that leaving the vehicle state resets the vehicle movement flag.
+ */
+class MotionDetectionFFTTest {
+
+    @Test
+    fun `isVehicleMoving resets when switching from vehicle to other modes`() = runBlocking {
+        val sig = mock(SignificantMotionSensor::class.java)
+        val lin = mock(LinearAccelerationSensor::class.java)
+        val acc = mock(AccelerometerSensor::class.java)
+        val dao = mock(FFTFeatureDao::class.java)
+        val repo = SensorDataColStateRepository()
+
+        val detector = MotionDetectionFFT(sig, lin, acc, dao, repo)
+
+        val toVehicle = MotionDetectionFFT::class.java.getDeclaredMethod("transitionToVehicle", Long::class.javaPrimitiveType).apply { isAccessible = true }
+        val toWalking = MotionDetectionFFT::class.java.getDeclaredMethod("transitionToWalking", Long::class.javaPrimitiveType).apply { isAccessible = true }
+        val toRunning = MotionDetectionFFT::class.java.getDeclaredMethod("transitionToRunning", Long::class.javaPrimitiveType).apply { isAccessible = true }
+        val toStationary = MotionDetectionFFT::class.java.getDeclaredMethod("transitionToStationary", Long::class.javaPrimitiveType).apply { isAccessible = true }
+
+        toVehicle.invoke(detector, System.currentTimeMillis())
+        delay(100)
+        assertTrue(repo.isVehicleMoving.value)
+
+        toWalking.invoke(detector, System.currentTimeMillis())
+        delay(100)
+        assertFalse(repo.isVehicleMoving.value)
+
+        toVehicle.invoke(detector, System.currentTimeMillis())
+        delay(100)
+        toRunning.invoke(detector, System.currentTimeMillis())
+        delay(100)
+        assertFalse(repo.isVehicleMoving.value)
+
+        toVehicle.invoke(detector, System.currentTimeMillis())
+        delay(100)
+        toStationary.invoke(detector, System.currentTimeMillis())
+        delay(100)
+        assertFalse(repo.isVehicleMoving.value)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Ensure walking, running, and stationary transitions clear vehicle movement flag
- Add unit test verifying `isVehicleMoving` resets when switching away from vehicle state

## Testing
- `gradle :sensor:test` *(fails: The file '/workspace/driveafrica/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689aeb400f0883329c519f5c116364a0