### PR TITLE
Fix map layout to keep Stop Monitoring button visible

### DIFF
--- a/sensor/src/main/java/com/uoa/sensor/presentation/ui/MapComposable.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/ui/MapComposable.kt
@@ -1,8 +1,11 @@
 package com.uoa.sensor.presentation.ui
 
 import android.content.Context
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.viewinterop.AndroidView
 import com.uoa.core.model.Road
 import org.osmdroid.config.Configuration
@@ -26,9 +29,15 @@ fun MapComposable(
     Configuration.getInstance().userAgentValue = context.packageName
 
     AndroidView(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize()
+            .clipToBounds(),
         factory = {
             MapView(it).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
                 setMultiTouchControls(true)
                 setBuiltInZoomControls(true)
                 controller.setZoom(15.0)

--- a/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreenUpdate.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreenUpdate.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -233,31 +234,38 @@ fun SensorControlScreenUpdate(
         }
 
         Spacer(modifier = Modifier.height(24.dp))
-
-        // Manual stop monitoring
-        if (serviceStarted) {
-            Button(onClick = {
-                context.stopService(Intent(context, VehicleMovementServiceUpdate::class.java))
-                serviceStarted = false
-            }) {
-                Icon(Icons.Filled.Stop, contentDescription = null)
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Stop Monitoring")
-            }
-        }
-
-        Spacer(Modifier.height(16.dp))
         currentLocation?.let { location ->
-            MapComposable(
-                context = context,
-                latitude = location.latitude,
-                longitude = location.longitude,
-                roads = roads,
-                path = pathPoints,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(250.dp)
-            )
+            ) {
+                MapComposable(
+                    context = context,
+                    latitude = location.latitude,
+                    longitude = location.longitude,
+                    roads = roads,
+                    path = pathPoints,
+                    modifier = Modifier
+                        .matchParentSize()
+                        .clipToBounds()
+                )
+                if (serviceStarted) {
+                    Button(
+                        onClick = {
+                            context.stopService(Intent(context, VehicleMovementServiceUpdate::class.java))
+                            serviceStarted = false
+                        },
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(16.dp)
+                    ) {
+                        Icon(Icons.Filled.Stop, contentDescription = null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Stop Monitoring")
+                    }
+                }
+            }
             Spacer(Modifier.height(8.dp))
             Column(modifier = Modifier.align(Alignment.Start)) {
                 Text(text = String.format("Distance travelled: %.2f km", distanceTravelled / 1000))


### PR DESCRIPTION
## Summary
- Wrap map and Stop Monitoring button inside a fixed-height Box so button stays visible
- Constrain MapComposable to its container by filling size, clipping to bounds, and setting layout params

## Testing
- `./gradlew :sensor:test` *(fails: The file '/workspace/driveafrica/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5943418c8332912700d7b3769ac9