### PR TITLE
Persist trip metrics in SensorViewModel using StateFlow

### DIFF
--- a/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreenUpdate.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreenUpdate.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -94,17 +93,8 @@ fun SensorControlScreenUpdate(
 
     val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
     var currentLocation by remember { mutableStateOf<GeoPoint?>(null) }
-    var distanceTravelled by rememberSaveable { mutableStateOf(0.0) }
-    val pathPoints = rememberSaveable(
-        saver = listSaver(
-            save = { list -> list.map { it.latitude to it.longitude } },
-            restore = { items ->
-                mutableStateListOf<GeoPoint>().apply {
-                    items.forEach { add(GeoPoint(it.first, it.second)) }
-                }
-            }
-        )
-    ) { mutableStateListOf<GeoPoint>() }
+    val distanceTravelled by sensorViewModel.distanceTravelled.collectAsState()
+    val pathPoints by sensorViewModel.pathPoints.collectAsState()
     val roads by roadViewModel.nearbyRoads.collectAsState()
 
     // Listen for location updates once permissions are granted
@@ -117,10 +107,7 @@ fun SensorControlScreenUpdate(
                     result.lastLocation?.let { location ->
                         val point = GeoPoint(location.latitude, location.longitude)
                         currentLocation = point
-                        if (pathPoints.isNotEmpty()) {
-                            distanceTravelled += pathPoints.last().distanceToAsDouble(point)
-                        }
-                        pathPoints += point
+                        sensorViewModel.addLocation(point)
                         roadViewModel.fetchNearbyRoads(location.latitude, location.longitude, 0.05)
                     }
                 }


### PR DESCRIPTION
## Summary
- Move distance travelled and path points tracking into `SensorViewModel` backed by `MutableStateFlow`
- Persist metrics with `SavedStateHandle` and add helper for location updates
- Collect new flows in `SensorControlScreenUpdate` so map and stats survive configuration changes

## Testing
- `./gradlew test` *(fails: The file '/workspace/driveafrica/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5949d310833296c6a6c9e1576233