### PR TITLE
Fix MapComposable icon and overlay issues

### DIFF
--- a/sensor/build.gradle.kts
+++ b/sensor/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
 //    implementation(libs.androidx.compose.compiler)
     implementation(libs.androidx.lifecycle.lifecycle.scope)
     implementation(libs.androidx.material3.android)
+    implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.lifecycle.runtimeCompose)
     implementation(libs.androidx.lifecycle.viewModelCompose)
     implementation(libs.androidx.hilt.navigation.compose)

--- a/sensor/src/main/java/com/uoa/sensor/presentation/ui/MapComposable.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/ui/MapComposable.kt
@@ -59,7 +59,6 @@ fun MapComposable(
         MyLocationNewOverlay(GpsMyLocationProvider(context), mapView).apply {
             enableMyLocation()
             enableFollowLocation()
-            enableCompass()
         }
     }
     val pathOverlay = remember(mapView) { Polyline() }
@@ -126,7 +125,7 @@ fun MapComposable(
                 .align(Alignment.BottomEnd)
                 .padding(16.dp)
         ) {
-            Icon(Icons.Filled.MyLocation, contentDescription = "Recenter")
+            Icon(imageVector = Icons.Filled.MyLocation, contentDescription = "Recenter")
         }
 
         // Stop Monitoring button (also stays visible)


### PR DESCRIPTION
## Summary
- add material icons dependency
- remove unsupported compass overlay call and specify icon vector

## Testing
- `./gradlew :sensor:test` *(fails: Failed to find Build Tools revision 34.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_689bc5bb846c83329b07876827dfeef0