### PR TITLE
Use base route to identify top-level destination

### DIFF
--- a/app/src/main/java/com/uoa/safedriveafrica/DaApp.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/DaApp.kt
@@ -158,8 +158,10 @@ fun DAContent(padding: PaddingValues, appState: DAAppState, snackbarHostState: S
     }
 }
 
-private fun NavDestination?.isTopLevelDestinationInHierarchy(topLevelDestinations: TopLevelDestinations)=
-        this?.hierarchy?.any{
-            it.route?.contains(topLevelDestinations.name) ?: false
-        } ?: false
+private fun NavDestination?.isTopLevelDestinationInHierarchy(
+    topLevelDestinations: TopLevelDestinations
+) =
+    this?.hierarchy?.any {
+        it.route?.startsWith(topLevelDestinations.route) == true
+    } ?: false
 

--- a/app/src/main/java/com/uoa/safedriveafrica/DaAppState.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/DaAppState.kt
@@ -17,14 +17,12 @@ import com.uoa.core.utils.Constants.Companion.DRIVER_PROFILE_ID
 import com.uoa.core.utils.Constants.Companion.PREFS_NAME
 import com.uoa.core.network.NetworkMonitor
 //import com.uoa.core.utils.TimeZoneMonitor
-import com.uoa.core.utils.HOME_SCREEN_ROUTE
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import com.uoa.safedriveafrica.presentation.daappnavigation.TopLevelDestinations
 import com.uoa.core.utils.FILTER_SCREEN_ROUTE
-import com.uoa.core.utils.REPORT_SCREEN_ROUTE
 import com.uoa.core.utils.SENSOR_CONTROL_SCREEN_ROUTE
 import android.app.Application
 import androidx.compose.ui.platform.LocalContext
@@ -69,11 +67,13 @@ class DAAppState(
         @Composable get() = navController.currentBackStackEntryAsState().value?.destination
 
     val currentTopLevelDestination: TopLevelDestinations?
-        @Composable get() = when (currentDestination?.route) {
-            HOME_SCREEN_ROUTE -> TopLevelDestinations.HOME
-            REPORT_SCREEN_ROUTE -> TopLevelDestinations.REPORTS
-//            SEARCH_ROUTE -> TopLevelDestinations.SEARCH
-            SENSOR_CONTROL_SCREEN_ROUTE -> TopLevelDestinations.RECORD_TRIP
+        @Composable get() = when {
+            currentDestination?.route?.startsWith(TopLevelDestinations.HOME.route) == true ->
+                TopLevelDestinations.HOME
+            currentDestination?.route?.startsWith(TopLevelDestinations.REPORTS.route) == true ->
+                TopLevelDestinations.REPORTS
+            currentDestination?.route?.startsWith(TopLevelDestinations.RECORD_TRIP.route) == true ->
+                TopLevelDestinations.RECORD_TRIP
             else -> null
         }
 

--- a/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/TopNavDestinations.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/TopNavDestinations.kt
@@ -1,26 +1,33 @@
 package com.uoa.safedriveafrica.presentation.daappnavigation
 
 import com.uoa.safedriveafrica.R
+import com.uoa.core.utils.HOME_SCREEN_ROUTE
+import com.uoa.core.utils.REPORT_SCREEN_ROUTE
+import com.uoa.core.utils.SENSOR_CONTROL_SCREEN_ROUTE
 
 // Define the top level destinations for the app
 enum class TopLevelDestinations(
     val selectedIcon: Int,
     val unselectedIconResId: Int, // Store the resource ID here
     val titleTextId: Int,
+    val route: String,
 ) {
     HOME(
         selectedIcon = R.drawable.home,
         unselectedIconResId = R.drawable.home, // Replace with your actual unselected home icon resource
         titleTextId = R.string.home,
+        route = HOME_SCREEN_ROUTE.substringBefore("/")
     ),
     REPORTS(
         selectedIcon = R.drawable.report, // Replace with the correct selected icon if needed
         unselectedIconResId = R.drawable.history, // Replace with your actual report icon resource
         titleTextId = R.string.reports,
+        route = REPORT_SCREEN_ROUTE
     ),
     RECORD_TRIP(
         selectedIcon =R.drawable.tips, // Replace with the correct selected icon if needed
         unselectedIconResId = R.drawable.tips, // Replace with your actual record trip icon resource
         titleTextId = R.string.record_trip,
+        route = SENSOR_CONTROL_SCREEN_ROUTE
     )
 }


### PR DESCRIPTION
## Summary
- Add `route` property to each `TopLevelDestinations` enum for base paths
- Determine current top level destination by checking the route prefix
- Match bottom bar selection using the new base route values

## Testing
- `./gradlew test` *(fails: The file '/workspace/driveafrica/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8b063d3483328787dcf5237b183f