### PR TITLE
Use route property for top-level navigation

### DIFF
--- a/app/src/main/java/com/uoa/safedriveafrica/DaAppState.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/DaAppState.kt
@@ -23,10 +23,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import com.uoa.safedriveafrica.presentation.daappnavigation.TopLevelDestinations
-import com.uoa.core.utils.FILTER_SCREEN_ROUTE
 import com.uoa.core.utils.REPORT_SCREEN_ROUTE
 import com.uoa.core.utils.SENSOR_CONTROL_SCREEN_ROUTE
-import android.app.Application
 import androidx.compose.ui.platform.LocalContext
 import com.uoa.core.utils.ENTRYPOINT_ROUTE
 
@@ -119,26 +117,17 @@ class DAAppState(
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val savedProfileId = prefs.getString(DRIVER_PROFILE_ID, null)
 
-        when (topLevelDestination) {
-            TopLevelDestinations.REPORTS -> {
-                navController.navigate(FILTER_SCREEN_ROUTE, topLevelNavOptions)
+        val resolvedRoute = if (topLevelDestination == TopLevelDestinations.HOME) {
+            if (savedProfileId != null) {
+                topLevelDestination.route.replace("{$DRIVER_PROFILE_ID}", savedProfileId)
+            } else {
+                ENTRYPOINT_ROUTE
             }
-            TopLevelDestinations.RECORD_TRIP -> {
-                navController.navigate(SENSOR_CONTROL_SCREEN_ROUTE, topLevelNavOptions)
-            }
-            TopLevelDestinations.HOME -> {
-                // IMPORTANT: We must supply the actual profileId in the route
-                if (savedProfileId != null) {
-                    // Build the full route: "homeScreen/<profile-id>"
-                    navController.navigate("homeScreen/$savedProfileId", topLevelNavOptions)
-                } else {
-                    // If no profile ID exists, decide how you want to handle it.
-                    // For example, you might navigate to the entry point or show a warning.
-                    navController.navigate(ENTRYPOINT_ROUTE, topLevelNavOptions)
-                    // Or show a Toast/snackbar, etc.
-                }
-            }
+        } else {
+            topLevelDestination.route
         }
+
+        navController.navigate(resolvedRoute, topLevelNavOptions)
     }
 
     fun canNavigateBack(): Boolean = navController.previousBackStackEntry != null

--- a/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/TopNavDestinations.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/TopNavDestinations.kt
@@ -1,25 +1,32 @@
 package com.uoa.safedriveafrica.presentation.daappnavigation
 
 import com.uoa.safedriveafrica.R
+import com.uoa.core.utils.FILTER_SCREEN_ROUTE
+import com.uoa.core.utils.HOME_SCREEN_ROUTE
+import com.uoa.core.utils.SENSOR_CONTROL_SCREEN_ROUTE
 
 // Define the top level destinations for the app
 enum class TopLevelDestinations(
+    val route: String,
     val selectedIcon: Int,
     val unselectedIconResId: Int, // Store the resource ID here
     val titleTextId: Int,
 ) {
     HOME(
+        route = HOME_SCREEN_ROUTE,
         selectedIcon = R.drawable.home,
         unselectedIconResId = R.drawable.home, // Replace with your actual unselected home icon resource
         titleTextId = R.string.home,
     ),
     REPORTS(
+        route = FILTER_SCREEN_ROUTE,
         selectedIcon = R.drawable.report, // Replace with the correct selected icon if needed
         unselectedIconResId = R.drawable.history, // Replace with your actual report icon resource
         titleTextId = R.string.reports,
     ),
     RECORD_TRIP(
-        selectedIcon =R.drawable.tips, // Replace with the correct selected icon if needed
+        route = SENSOR_CONTROL_SCREEN_ROUTE,
+        selectedIcon = R.drawable.tips, // Replace with the correct selected icon if needed
         unselectedIconResId = R.drawable.tips, // Replace with your actual record trip icon resource
         titleTextId = R.string.record_trip,
     )


### PR DESCRIPTION
## Summary
- Attach routes to TopLevelDestinations and navigate using these routes
- Resolve home route with saved profile ID before navigation

## Testing
- `./gradlew test` *(fails: The file '/workspace/driveafrica/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8b0a155c8332b59501c52d2df6a7