### PR TITLE
Use routes for top-level destination selection

### DIFF
--- a/app/src/main/java/com/uoa/safedriveafrica/DaApp.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/DaApp.kt
@@ -111,31 +111,32 @@ fun DABottomBar(destinations:List<TopLevelDestinations>,
                 currentDestination: NavDestination?
 ) {
     NavigationBar {
-        destinations.forEach{ destination->
-            val selected=currentDestination.isTopLevelDestinationInHierarchy(destination)
+        val currentRoute = currentDestination?.route?.substringBefore("/")
+        destinations.forEach { destination ->
+            val selected = currentRoute == destination.route
             DaAppNavigationBarItem(
-                selected=selected,
-                onClick={onNavigateToDestination(destination)},
+                selected = selected,
+                onClick = { onNavigateToDestination(destination) },
 
-                icon={
+                icon = {
                     Icon(
                         painterResource(destination.unselectedIconResId),
-                        contentDescription=null
+                        contentDescription = null
                     )
                 },
-                selectedIcon={
+                selectedIcon = {
                     Icon(
                         painterResource(destination.selectedIcon),
-                        contentDescription=null
+                        contentDescription = null
                     )
                 },
 
-                label={
+                label = {
                     Text(
-                        text=stringResource(id=destination.titleTextId)
+                        text = stringResource(id = destination.titleTextId)
                     )
                 },
-                enabled=true,
+                enabled = true,
             )
         }
     }
@@ -158,8 +159,8 @@ fun DAContent(padding: PaddingValues, appState: DAAppState, snackbarHostState: S
     }
 }
 
-private fun NavDestination?.isTopLevelDestinationInHierarchy(topLevelDestinations: TopLevelDestinations)=
-        this?.hierarchy?.any{
-            it.route?.contains(topLevelDestinations.name) ?: false
-        } ?: false
+private fun NavDestination?.isTopLevelDestinationInHierarchy(topLevelDestination: TopLevelDestinations): Boolean {
+    val destinationRoute = this?.route?.substringBefore("/")
+    return destinationRoute == topLevelDestination.route
+}
 

--- a/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/TopNavDestinations.kt
+++ b/app/src/main/java/com/uoa/safedriveafrica/presentation/daappnavigation/TopNavDestinations.kt
@@ -7,20 +7,24 @@ enum class TopLevelDestinations(
     val selectedIcon: Int,
     val unselectedIconResId: Int, // Store the resource ID here
     val titleTextId: Int,
+    val route: String,
 ) {
     HOME(
         selectedIcon = R.drawable.home,
         unselectedIconResId = R.drawable.home, // Replace with your actual unselected home icon resource
         titleTextId = R.string.home,
+        route = "homeScreen",
     ),
     REPORTS(
         selectedIcon = R.drawable.report, // Replace with the correct selected icon if needed
         unselectedIconResId = R.drawable.history, // Replace with your actual report icon resource
         titleTextId = R.string.reports,
+        route = "filterScreen",
     ),
     RECORD_TRIP(
         selectedIcon =R.drawable.tips, // Replace with the correct selected icon if needed
         unselectedIconResId = R.drawable.tips, // Replace with your actual record trip icon resource
         titleTextId = R.string.record_trip,
+        route = "sensorControlScreen",
     )
 }


### PR DESCRIPTION
## Summary
- define `route` on `TopLevelDestinations` enum to represent base routes
- compare current destination route to each top-level route to mark bottom bar selection
- replace helper with route-based comparison stripping dynamic segments

## Testing
- `./gradlew test` *(fails: The file 'local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8b04ac28833296653ec034caa537