### PR TITLE
Show speed limit when location unavailable

### DIFF
--- a/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreenUpdate.kt
+++ b/sensor/src/main/java/com/uoa/sensor/presentation/ui/SensorControlScreenUpdate.kt
@@ -222,31 +222,34 @@ fun SensorControlScreenUpdate(
                     }
                 }
 
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
-                ) {
-                    Row(
-                        modifier = Modifier.padding(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Speed,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            text = stringResource(
-                                R.string.speed_limit,
-                                speedLimit,
-                                stringResource(R.string.unit_kilometers_per_hour)
-                            ),
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+        ) {
+            Row(
+                modifier = Modifier.padding(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Speed,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(Modifier.width(8.dp))
+                val speedText = if (currentLocation == null) "--" else speedLimit.toString()
+                Text(
+                    text = stringResource(
+                        R.string.speed_limit,
+                        speedText,
+                        stringResource(R.string.unit_kilometers_per_hour)
+                    ),
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
             }
         }
     }

--- a/sensor/src/main/res/values/strings.xml
+++ b/sensor/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">sensor</string>
     <string name="distance_travelled">Distance travelled: %1$.2f %2$s</string>
-    <string name="speed_limit">Speed limit: %1$d %2$s</string>
+    <string name="speed_limit">Speed limit: %1$s %2$s</string>
     <string name="unit_kilometers">km</string>
     <string name="unit_kilometers_per_hour">km/h</string>
 </resources>


### PR DESCRIPTION
## Summary
- Move speed-limit card outside of location check and show placeholder when location is null
- Allow string resource to accept placeholder value

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d915209a0833298b34b28f3d623c9