### PR TITLE
Handle invalid Trip ID in DataCollectionService

### DIFF
--- a/sensor/src/main/java/com/uoa/sensor/services/DataCollectionService.kt
+++ b/sensor/src/main/java/com/uoa/sensor/services/DataCollectionService.kt
@@ -33,7 +33,17 @@ class DataCollectionService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val tripIdString = intent?.getStringExtra("TRIP_ID")
-        val tripId = tripIdString?.let { UUID.fromString(it) }
+        val tripId = tripIdString?.let {
+            runCatching { UUID.fromString(it) }
+                .onFailure { e ->
+                    Log.e(
+                        "DataCollectionService",
+                        "Invalid Trip ID provided: $it",
+                        e
+                    )
+                }
+                .getOrNull()
+        }
 
         if (tripId != null) {
             startDataCollection(tripId)


### PR DESCRIPTION
## Summary
- Wrap `UUID.fromString` in `runCatching` and log/stop service on failure

## Testing
- `./gradlew :sensor:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd16f976c8332a9a2f76cf2c132d1